### PR TITLE
feature: add age PKCS protocol for sops

### DIFF
--- a/repositories/age_repositories.bzl
+++ b/repositories/age_repositories.bzl
@@ -1,0 +1,33 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def age_repositories():
+    http_archive(
+        name = "age_darwin_amd64",
+        # The BUILD file is really a few convenience aliases (may remove later, or convert to list)
+        # You can test whether it's resolving for your architcture using:
+
+        #     bazel run @age_darwin_amd64//:age -- --version
+        build_file_content = "\n".join([
+            """alias(name="age", actual="//:age/age", visibility = ["//visibility:public"])""",
+            """alias(name="age-keygen", actual="//:age/age-keygen", visibility = ["//visibility:public"])""",
+            "",  # readability during debug
+        ]),
+        sha256 = "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c",
+        urls = [
+            "https://github.com/FiloSottile/age/releases/download/v1.1.1/age-v1.1.1-darwin-amd64.tar.gz",
+        ],
+    )
+
+    http_archive(
+        name = "age_linux_amd64",
+        # The BUILD file is really a few convenience aliases (may remove later, or convert to slice)
+        build_file_content = "\n".join([
+            """alias(name="age", actual="//:age/age", visibility = ["//visibility:public"])""",
+            """alias(name="age-keygen", actual="//:age/age-keygen", visibility = ["//visibility:public"])""",
+            "",  # readability during debug
+        ]),
+        sha256 = "cf16cbb108fc56e2064b00ba2b65d9fb1b8d7002ca5e38260ee1cc34f6aaa8f9",
+        urls = [
+            "https://github.com/FiloSottile/age/releases/download/v1.1.1/age-v1.1.1-linux-amd64.tar.gz",
+        ],
+    )

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@com_github_masmovil_bazel_rules//repositories:age_repositories.bzl", "age_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:helm_repositories.bzl", "helm_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:yq_repositories.bzl", "yq_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:kubectl_repositories.bzl", "kubectl_repositories")
@@ -13,6 +14,7 @@ def repositories():
   """Download dependencies of container rules."""
   excludes = native.existing_rules().keys()
 
+  age_repositories()
   kubectl_repositories()
   helm_repositories()
   yq_repositories()
@@ -40,5 +42,7 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_arm64_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/sops:sops_windows_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_osx_toolchain",
-    "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_linux_toolchain"
+    "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_linux_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/age:age_osx_amd64_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/age:age_linux_amd64_toolchain",
   )

--- a/toolchains/age/BUILD
+++ b/toolchains/age/BUILD
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:private"])
+
+load(":age_toolchain.bzl", "age_toolchain")
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+# Age toolchain that points to age binary plus age-keygen
+age_toolchain(
+    name = "age_osx_amd64",
+    keygen = "@age_darwin_amd64//:age-keygen",
+    tool = "@age_darwin_amd64//:age",
+    visibility = ["//visibility:public"],
+)
+
+age_toolchain(
+    name = "age_linux_amd64",
+    keygen = "@age_linux_amd64//:age-keygen",
+    tool = "@age_linux_amd64//:age",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "age_osx_amd64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":age_osx_amd64",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "age_linux_amd64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":age_linux_amd64",
+    toolchain_type = ":toolchain_type",
+)

--- a/toolchains/age/age_toolchain.bzl
+++ b/toolchains/age/age_toolchain.bzl
@@ -1,0 +1,26 @@
+AgeToolchainInfo = provider(
+    # "age" spoken like "Ah Ge", "Ge" like "Getter" not "Jetter"; author Filippo Valsorda also
+    # prefers lowercase "age" not "Age", but I'm inconsistent about honouring that
+    doc = "Age toolchain",
+    fields = {
+        "keygen": "Age-Keygen executable binary",
+        "tool": "Age executable binary",
+    },
+)
+
+def _age_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        ageinfo = AgeToolchainInfo(
+            keygen = ctx.attr.keygen,
+            tool = ctx.attr.tool,
+        ),
+    )
+    return [toolchain_info]
+
+age_toolchain = rule(
+    implementation = _age_toolchain_impl,
+    attrs = {
+        "keygen": attr.label(allow_single_file = True, doc = "age-keygen binary"),
+        "tool": attr.label(allow_single_file = True, doc = "age binary"),
+    },
+)


### PR DESCRIPTION
This PR adds the `age` toolchain (`age`, `age-keygen`) so that SOPS can use this protocol to decrypt on-the-fly.  Additionally, in testing, I'm encrypting secrets using pseudorandom keys to confirm that constants and assumptions are more difficult to sneak in (I can merge these E2E to MasMovil if desired)

I could create another repo to hold this toolchain -- and I did to work on this PR -- but I'd rather commit this to a common resource to more easily enable others to use it.