### PR TITLE
ci: exercise examples to validate on CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --enable_bzlmod
+common --enable_bzlmod
 
 test:ci --workspace_status_command=$GITHUB_WORKSPACE/stamp.sh
 

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,3 +18,11 @@ jobs:
     - name: Run integration tests
       run: |
         bazel test //... --config=ci
+    - name: Validate Examples
+      # rules_bazel_integration_test doesn't apply to a lone subdir
+      # even so, I'd parallelize with a matrix of <example> x <arch>
+      #
+      # after this test, the checkout is *dirty*: the //examples/ has its own bazel-* links, which
+      # cannot be excluded with .bazelignore
+      run: |
+        (cd examples/ && bazel test //... --config=ci)


### PR DESCRIPTION
This local PR should check that the validation of examples after basic-test in CI is functional.

Ordinarily depends on #101 for the unrelated but necessary change to `.bazelrc` (One PR per action)